### PR TITLE
Feat: log errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function getStatic(file) {
 }
 
 const consoleScript = getStatic('console.js');
+const onErrorScript = getStatic('onerror.js');
 const style = getStatic('style.css');
 
 function getSource(src, callback) {
@@ -50,6 +51,7 @@ function sendSource(src, resp) {
 module.exports = function serve(options = {}) {
   const data = {
     consoleScript,
+    onErrorScript,
     style,
     noConsole: !!options.noConsole,
   };

--- a/static/index.js
+++ b/static/index.js
@@ -5,6 +5,7 @@ module.exports = function template(data) {
         <title>Test Page</title>
         ${!data.noConsole ? `<style>${data.style}</style>` : ''}
     </head>
+    <div id="errors"></div>
     ${
       !data.noConsole
         ? `
@@ -21,6 +22,7 @@ module.exports = function template(data) {
     `
         : ''
     }
+    <script>${data.onErrorScript}</script>
     <script src="script.js"></script>
 </html>`;
 };

--- a/static/onerror.js
+++ b/static/onerror.js
@@ -1,0 +1,16 @@
+/* eslint no-var: 0 prefer-template: 0 */
+function windowOnError() {
+  var output = document.getElementById('errors');
+
+  function logError(message, source, lineno, colno) {
+    const line = message + ' in ' + source + ', line ' + lineno + ':' + colno;
+    const node = document.createElement('pre');
+    node.appendChild(document.createTextNode(line));
+    output.appendChild(node);
+    output.appendChild(document.createTextNode('\r\n'));
+  }
+
+  window.onerror = logError;
+}
+
+windowOnError();

--- a/static/style.css
+++ b/static/style.css
@@ -41,6 +41,15 @@ input {
     margin-top: 10px;
 }
 
+#errors {
+    background-color: #DD0000;
+    color: #FFFFFF;
+}
+
+#errors pre {
+    padding: 4px 10px;
+}
+
 /* Use :not to prevent IE8 from hiding all the messages */
 #log-filter:not(:checked) ~ #output .log,
 #debug-filter:not(:checked) ~ #output .debug,


### PR DESCRIPTION
Attach a function to window.onerror which adds error messages to a new error container.

![screenshot 2018-04-06 15 00 37](https://user-images.githubusercontent.com/404731/38446145-6d34a544-39ab-11e8-9e6e-70f093d2a364.png)
